### PR TITLE
:sparkles::lipstick: (feature/halam/#6) Box 컴포넌트 생성

### DIFF
--- a/studymate/src/components/common/Box.jsx
+++ b/studymate/src/components/common/Box.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+function Box({ children, ...props }) {
+  return <Wrapper {...props}>{children}</Wrapper>;
+}
+
+export default Box;
+
+const Wrapper = styled.div`
+  width: ${(props) => props.size[0]}px;
+  height: ${(props) => props.size[1]}px;
+  border-radius: ${(props) => (props.place === 'outer' ? '40px' : '25px')};
+  background-color: ${(props) => `rgba(255,255,255,${props.opacity})`};
+  box-shadow: 2px 4px 10px rgba(0, 0, 0, 0.25);
+`;


### PR DESCRIPTION
- props :
  - **size** : 배열 형태 [width, height] / ex) `size={[300, 200]}`
  - **place** : border-radius
    - 메인 컨테이너의 경우 'outer' 사용
    - 작은 박스 같이 안에서 사용하는 경우 해당 props 사용 x
    - ex) `place={'outer'}`
  - **opacity** : 배경 색의 투명도 (rgba에서의 알파값) / ex) `opacity={0.5}`