### PR TITLE
:sparkles:(feature/halam/#23): Calendar 데이터 형식 바꾸는 기능 구현

### DIFF
--- a/studymate/package-lock.json
+++ b/studymate/package-lock.json
@@ -20,6 +20,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "date-fns": "^2.29.3",
+        "moment": "^2.29.4",
         "react": "^18.2.0",
         "react-axios": "^2.0.6",
         "react-day-picker": "^8.3.1",

--- a/studymate/package.json
+++ b/studymate/package.json
@@ -15,6 +15,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "date-fns": "^2.29.3",
+    "moment": "^2.29.4",
     "react": "^18.2.0",
     "react-axios": "^2.0.6",
     "react-day-picker": "^8.3.1",

--- a/studymate/src/components/calendar/Calendar.jsx
+++ b/studymate/src/components/calendar/Calendar.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import moment from 'moment';
 import styled from '@emotion/styled';
 
 import Box from '../common/Box';
@@ -28,15 +29,20 @@ function CustomCaption(props) {
   );
 }
 
-function Calendar() {
+function Calendar({ resultData, setResultData }) {
   const [selected, setSelected] = useState();
 
   useEffect(() => {
-    if (selected) {
-      console.log('selected :>> ', selected);
+    if (!selected) {
+      setResultData(undefined);
+    }
+    if (selected?.from) {
+      setResultData(resultData => ({ ...resultData, from: moment(selected.from).format().slice(0, 10) }));
+      if (selected.to) {
+        setResultData(resultData => ({ ...resultData, to: moment(selected.to).format().slice(0, 10) }));
+      }
     }
   }, [selected]);
-
   return (
     <Wrapper size={[214, 214]} opacity={0.8}>
       <DayPicker


### PR DESCRIPTION
### 참고사항
- Calendar 컴포넌트에서 props 2개를 받도록 수정했습니다. 
- Calendar 컴포넌트를 사용하는 곳에서 state변수와 setState 함수를 Calendar 컴포넌트로 넘겨주어야 합니다.
   - `resultData`, `setResultData`
- Calendar 컴포넌트를 사용하는 곳에서 useEffect를 통해 resultData를 출력하면 선택한 날짜가 원하는 데이터 형식에 맞게 바뀐 것을 볼 수 있습니다.

### 사용예시
![image](https://user-images.githubusercontent.com/87893624/194960153-bd8a20d5-1995-46cf-b3ed-8321fb8bfb75.png)
![image](https://user-images.githubusercontent.com/87893624/194960257-5394d0c3-7498-49b3-aefb-8aad36c01af4.png)
